### PR TITLE
Add node types for containers and processes

### DIFF
--- a/api/antimetal/runtime/v1/linux.proto
+++ b/api/antimetal/runtime/v1/linux.proto
@@ -102,47 +102,47 @@ enum ProcessState {
 message ContainerNode {
   // container_id is the unique identifier for the container (may be truncated for some runtimes).
   string container_id = 1;
-  
+
   // runtime identifies the container runtime that manages this container.
   ContainerRuntime runtime = 2;
-  
+
   // cgroup_version indicates whether this container uses cgroup v1 or v2.
   // Different runtimes on the same host may use different cgroup versions.
   CgroupVersion cgroup_version = 3;
-  
+
   // cgroup_path is the filesystem path to the container's cgroup directory.
   string cgroup_path = 4;
-  
+
   // image_name is the container image name (e.g., "nginx", "alpine").
   string image_name = 5;
-  
+
   // image_tag is the container image tag (e.g., "latest", "1.21").
   string image_tag = 6;
-  
+
   // labels contains runtime-specific labels and annotations.
   map<string, string> labels = 7;
-  
+
   // created_at is when the container was created.
   google.protobuf.Timestamp created_at = 8;
-  
+
   // started_at is when the container was started (may differ from created_at).
   google.protobuf.Timestamp started_at = 9;
-  
+
   // cpu_shares represents the relative CPU weight (cgroup v1 cpu.shares).
   optional int32 cpu_shares = 10;
-  
+
   // cpu_quota_us represents the CPU quota in microseconds per period.
   optional int32 cpu_quota_us = 11;
-  
+
   // cpu_period_us represents the CPU quota enforcement period in microseconds.
   optional int32 cpu_period_us = 12;
-  
+
   // memory_limit_bytes represents the memory limit in bytes (if set).
   optional uint64 memory_limit_bytes = 13;
-  
+
   // cpuset_cpus contains the CPU cores this container is allowed to use.
   string cpuset_cpus = 14;
-  
+
   // cpuset_mems contains the NUMA memory nodes this container is allowed to use.
   string cpuset_mems = 15;
 }
@@ -152,25 +152,25 @@ message ContainerNode {
 message ProcessNode {
   // pid is the process identifier.
   int32 pid = 1;
-  
+
   // ppid is the parent process identifier.
   int32 ppid = 2;
-  
+
   // pgid is the process group identifier.
   int32 pgid = 3;
-  
+
   // sid is the session identifier.
   int32 sid = 4;
-  
+
   // command is the process command name.
   string command = 5;
-  
+
   // cmdline is the full command line with arguments.
   string cmdline = 6;
-  
+
   // state is the current process state.
   ProcessState state = 7;
-  
+
   // start_time is when the process was started.
   google.protobuf.Timestamp start_time = 8;
 }


### PR DESCRIPTION
system-agent will be responsible for maintaining a mapping of the running processes and containers in our graph.

Existing relationships will be used to link these nodes to system and kubernetes nodes.

See: https://github.com/antimetal/system-agent/wiki/Runtime-Discovery for the details of how this will be used