### PR TITLE
feat: add Contains and ContainedBy relationships for runtime

### DIFF
--- a/api/antimetal/runtime/v1/linux.proto
+++ b/api/antimetal/runtime/v1/linux.proto
@@ -194,5 +194,5 @@ message ContainedBy {
 // ContainmentType represents types of containment relationships
 enum ContainmentType {
   CONTAINMENT_TYPE_UNKNOWN = 0;
-  CONTAINMENT_TYPE_RUNTIME = 1;      // Runtime containment (e.g., container contains process)
+  CONTAINMENT_TYPE_RUNTIME = 1; // Runtime containment (e.g., container contains process)
 }


### PR DESCRIPTION
## Summary
- Add `Contains` and `ContainedBy` relationship messages to runtime proto
- Add `ContainmentType` enum with `CONTAINMENT_TYPE_RUNTIME` for container-to-process relationships
- Follow same pattern as hardware relationships for consistency

## Test plan
- [ ] Verify proto compilation succeeds
- [ ] Confirm relationship types can model container-process hierarchies