### PR TITLE
feat: add host namespace

### DIFF
--- a/api/resource/v1/namespace.proto
+++ b/api/resource/v1/namespace.proto
@@ -16,6 +16,7 @@ message Namespace {
   oneof namespace {
     CloudNamespace cloud = 1;
     KubernetesNamespace kube = 2;
+    HostNamespace host = 3;
   }
 }
 
@@ -30,4 +31,10 @@ message CloudNamespace {
 message KubernetesNamespace {
   string cluster = 1;
   string namespace = 2;
+}
+
+// HostNamespace specifies the namespace scope for a resource located on a host machine.
+message HostNamespace {
+  string host = 1;
+  string container = 2;
 }


### PR DESCRIPTION
For identifying processes in the graph.

PR https://github.com/antimetal/system-agent/pull/169 adds containers and processes using the KubernetesNamespace which is weird because these are not Kubernetes concepts. There's actually no "Container" resource in Kubernetes - the lowest level primitive is a Pod which is a collection of containers that share a network namespace. Containers can also be managed by platforms other than K8s (e.g. Docker)

So create a HostNamespace container to better reflect this. It includes host which identifies the host the container/process is on and an optional container scope for PIDs inside a container or even containers within containers.

