### PR TITLE
feat(runtime): add container-specific human-readable name fields to ContainerNode

### DIFF
--- a/api/antimetal/runtime/v1/linux.proto
+++ b/api/antimetal/runtime/v1/linux.proto
@@ -145,6 +145,21 @@ message ContainerNode {
 
   // cpuset_mems contains the NUMA memory nodes this container is allowed to use.
   string cpuset_mems = 15;
+
+  // === Human-Readable Identifiers ===
+  // Container-specific human-readable names for simplified operator queries.
+  // Note: Pod-level fields (pod name, namespace, app) are available in Pod resources
+  // and should be accessed via Container→Pod relationships to avoid duplication.
+
+  // container_name is the human-readable container name (e.g., "nginx", "web", "sidecar").
+  // Extracted from io.kubernetes.container.name (K8s) or com.docker.compose.service (Docker).
+  // Falls back to image_name if no explicit container name is available.
+  string container_name = 16;
+
+  // workload_name is the Kubernetes workload name with ReplicaSet hash stripped.
+  // Examples: "web-server-7d4f8-abc" → "web-server", "nginx-deployment-xyz" → "nginx-deployment"
+  // Only populated for Kubernetes containers. For pod name/namespace/app, use Pod resource relationships.
+  string workload_name = 17;
 }
 
 // ProcessNode represents a running process in the runtime topology.


### PR DESCRIPTION
## Summary

Adds 2 container-specific human-readable identifier fields to `ContainerNode` for simplified operator queries without duplicating Kubernetes Pod resource data.

### New Fields

- **`container_name`** (field 16): Container name from K8s/Docker labels or image name fallback
- **`workload_name`** (field 17): Kubernetes workload name with ReplicaSet hash stripped

## Field Behavior Across Environments

### Kubernetes Containers

**`container_name`** is extracted from `io.kubernetes.container.name` label:
```
Label: io.kubernetes.container.name=nginx
Result: container_name="nginx"
```

**`workload_name`** strips ReplicaSet and Pod hashes from pod names:
```
Pod name: web-server-7d4f8bd9c-abc12
Result: workload_name="web-server"

Pod name: cassandra-0 (StatefulSet)
Result: workload_name="cassandra-0"  (no hash to strip)
```

### Docker Compose Containers

**`container_name`** uses Docker Compose service name:
```yaml
# docker-compose.yml
services:
  web:
    image: nginx:latest

Label: com.docker.compose.service=web
Result: container_name="web"
```

**`workload_name`** is empty (Kubernetes-specific field):
```
Result: workload_name=""
```

### Standalone Docker Containers

**`container_name`** falls back to image name when no explicit name label exists:
```bash
docker run nginx:1.21

No explicit name label
Result: container_name="nginx"  (from image_name)
```

**`workload_name`** is empty (Kubernetes-specific field):
```
Result: workload_name=""
```

## Design Decision: Container-Specific Fields Only

These fields are **container-specific** to avoid duplicating data already in Kubernetes Pod resources:

**✅ Stored in ContainerNode:**
- `container_name` - Not in Pod metadata (it's in `spec.containers[].name`)
- `workload_name` - Derived/computed field not available in Pod

**❌ NOT stored (access via Pod relationships):**
- `pod_name` → Available in `Pod.metadata.name`
- `namespace` → Available in `Pod.metadata.namespace`
- `app_name` → Available in `Pod.metadata.labels["app"]`

Operators can use Container→Pod relationships to access Pod-level metadata, maintaining single source of truth for Kubernetes data.

## Example Queries

**Direct container queries (no joins needed):**
```bash
# Find all nginx containers (works in K8s, Docker, Compose)
select(.container_name == "nginx")

# Find containers from web-server deployment (K8s only)
select(.workload_name == "web-server")
```

**Pod-level queries (via relationships):**
```bash
# Find containers in production namespace
# 1. Get Pod resources where namespace == "production"
# 2. Follow Pod→Container relationships

# Find containers for "frontend" app
# 1. Get Pod resources where labels.app == "frontend"
# 2. Follow Pod→Container relationships
```

## Benefits

✅ **Works across runtimes** - Kubernetes, Docker, containerd, CRI-O, Podman  
✅ **No data duplication** - Pod metadata stays in Pod resources  
✅ **Single source of truth** - K8s data comes from K8s resources  
✅ **Container-specific focus** - Only container-level identifiers  
✅ **Graceful fallbacks** - Uses image name when no explicit name available